### PR TITLE
Add the plurality "MANY" for russian and polish language

### DIFF
--- a/LocMapper/RefLoc Support/Utilities/Std2Xib.swift
+++ b/LocMapper/RefLoc Support/Utilities/Std2Xib.swift
@@ -212,7 +212,7 @@ public struct Std2Xib {
 			} else if Set(["danish", "dutch", "english", "french", "german", "greek", "hindi", "hungarian", "italian", "norwegian", "portuguese", "spanish", "swedish", "telugu", "turkish"]).contains(where: { language.range(of: $0) != nil }) {
 				pluralValues = [.one, .other]
 			} else if Set(["polish", "russian"]).contains(where: { language.range(of: $0) != nil }) {
-				pluralValues = [.one, .few, .other]
+				pluralValues = [.one, .few, .many, .other]
 			} else {
 				throw Std2XibError.unknownLanguage
 			}


### PR DESCRIPTION
Add plurality "MANY" in russian and polish, so we can get the good translation via XibLoc for a plural value.
Russian exemple:
ONE -> У вас [%1$d:2] общий интерес
FEW -> У вас [%1$d:2] общих интереса
MANY -> У вас [%1$d:2] общих интересов
OTHER -> У вас [%1$d:2] общий интерес